### PR TITLE
apiserver: Put security groups behind a feature flag

### DIFF
--- a/deploy/nexodus/base/apiserver/deployment.yaml
+++ b/deploy/nexodus/base/apiserver/deployment.yaml
@@ -98,6 +98,11 @@ spec:
                 configMapKeyRef:
                   name: apiserver
                   key: NEXAPI_TRACE_INSECURE
+            - name: NEXAPI_FFLAG_SECURITY_GROUPS
+              valueFrom:
+                configMapKeyRef:
+                  name: apiserver
+                  key: NEXAPI_FFLAG_SECURITY_GROUPS
             - name: NEXAPI_REDIRECT_URL
               valueFrom:
                 configMapKeyRef:

--- a/deploy/nexodus/base/apiserver/kustomization.yaml
+++ b/deploy/nexodus/base/apiserver/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
       - NEXAPI_INSECURE_TLS=1
       - NEXAPI_TRACE_ENDPOINT_OTLP="tempo.nexodus-monitoring.svc:4317"
       - NEXAPI_TRACE_INSECURE="1"
+      - NEXAPI_FFLAG_SECURITY_GROUPS=false
       - NEXAPI_DB_SSLMODE=require
       - NEXAPI_DOMAIN=api.try.nexodus.127.0.0.1.nip.io
       - NEXAPI_REDIRECT_URL=https://try.nexodus.127.0.0.1.nip.io/#/login

--- a/deploy/nexodus/overlays/dev/kustomization.yaml
+++ b/deploy/nexodus/overlays/dev/kustomization.yaml
@@ -8,6 +8,11 @@ components:
 # Uncomment this to enable rate limiting
 #  - ../../components/promtail
 namespace: nexodus
+configMapGenerator:
+  - behavior: merge
+    literals:
+      - NEXAPI_FFLAG_SECURITY_GROUPS=true
+    name: apiserver
 patches:
   - target:
       kind: Ingress

--- a/internal/fflags/fflags.go
+++ b/internal/fflags/fflags.go
@@ -24,6 +24,7 @@ type FFlag struct {
 
 var hardCodedFlags = map[string]FFlag{
 	"multi-organization": {"NEXAPI_FFLAG_MULTI_ORGANIZATION", true},
+	"security-groups":    {"NEXAPI_FFLAG_SECURITY_GROUPS", false},
 }
 
 func NewFFlags(logger *zap.SugaredLogger) *FFlags {

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -3,13 +3,14 @@ package handlers
 import (
 	"context"
 	"errors"
-	"github.com/nexodus-io/nexodus/internal/signalbus"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+
+	"github.com/nexodus-io/nexodus/internal/signalbus"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -26,7 +27,7 @@ import (
 const (
 	TestUserID     = "f606de8d-092d-4606-b981-80ce9f5a3b2a"
 	TestUser2ID    = "3381dcaf-f61e-4671-8787-3e53490894ae"
-	ipamClientAddr = "http://localhost:9090"
+	ipamClientAddr = "http://localhost:49090"
 )
 
 type HandlerTestSuite struct {
@@ -49,7 +50,7 @@ func (suite *HandlerTestSuite) SetupSuite() {
 	suite.wg = &sync.WaitGroup{}
 	suite.wg.Add(1)
 
-	listener, err := net.Listen("tcp", "[::1]:9090")
+	listener, err := net.Listen("tcp", "[::1]:49090")
 	suite.Require().NoError(err)
 
 	go func() {

--- a/internal/handlers/security_group_test.go
+++ b/internal/handlers/security_group_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/gin-gonic/gin"
+
 	"github.com/nexodus-io/nexodus/internal/models"
 )
 
@@ -63,7 +65,11 @@ func (suite *HandlerTestSuite) TestCreateGetSecurityGroups() {
 		_, res, err := suite.ServeRequest(
 			http.MethodPost,
 			"/organizations/:organization/security_groups", fmt.Sprintf("/organizations/%s/security_groups", suite.testOrganizationID.String()),
-			suite.api.CreateSecurityGroup, bytes.NewBuffer(resBody),
+			func(c *gin.Context) {
+				c.Set("nexodus.secGroupsEnabled", "true")
+				suite.api.CreateSecurityGroup(c)
+			},
+			bytes.NewBuffer(resBody),
 		)
 		require.NoError(err)
 
@@ -117,7 +123,11 @@ func (suite *HandlerTestSuite) TestDeleteSecurityGroup() {
 	_, res, err := suite.ServeRequest(
 		http.MethodPost,
 		"/organizations/:organization/security_groups", fmt.Sprintf("/organizations/%s/security_groups", suite.testOrganizationID.String()),
-		suite.api.CreateSecurityGroup, bytes.NewBuffer(resBody),
+		func(c *gin.Context) {
+			c.Set("nexodus.secGroupsEnabled", "true")
+			suite.api.CreateSecurityGroup(c)
+		},
+		bytes.NewBuffer(resBody),
 	)
 	require.NoError(err)
 
@@ -134,7 +144,11 @@ func (suite *HandlerTestSuite) TestDeleteSecurityGroup() {
 	_, res, err = suite.ServeRequest(
 		http.MethodDelete,
 		"/organizations/:organization/security_groups/:id", fmt.Sprintf("/organizations/%s/security_groups/%s", suite.testOrganizationID.String(), actual.ID),
-		suite.api.DeleteSecurityGroup, nil,
+		func(c *gin.Context) {
+			c.Set("nexodus.secGroupsEnabled", "true")
+			suite.api.DeleteSecurityGroup(c)
+		},
+		nil,
 	)
 
 	require.NoError(err)
@@ -179,7 +193,11 @@ func (suite *HandlerTestSuite) TestListSecurityGroups() {
 		_, res, err := suite.ServeRequest(
 			http.MethodPost,
 			"/organizations/:organization/security_groups", fmt.Sprintf("/organizations/%s/security_groups", suite.testOrganizationID.String()),
-			suite.api.CreateSecurityGroup, bytes.NewBuffer(resBody),
+			func(c *gin.Context) {
+				c.Set("nexodus.secGroupsEnabled", "true")
+				suite.api.CreateSecurityGroup(c)
+			},
+			bytes.NewBuffer(resBody),
 		)
 		require.NoError(err)
 		require.Equal(http.StatusCreated, res.Code)
@@ -225,7 +243,11 @@ func (suite *HandlerTestSuite) TestUpdateSecurityGroup() {
 	_, res, err := suite.ServeRequest(
 		http.MethodPost,
 		"/organizations/:organization/security_groups", fmt.Sprintf("/organizations/%s/security_groups", suite.testOrganizationID.String()),
-		suite.api.CreateSecurityGroup, bytes.NewBuffer(resBody),
+		func(c *gin.Context) {
+			c.Set("nexodus.secGroupsEnabled", "true")
+			suite.api.CreateSecurityGroup(c)
+		},
+		bytes.NewBuffer(resBody),
 	)
 	require.NoError(err)
 	require.Equal(http.StatusCreated, res.Code)
@@ -251,7 +273,11 @@ func (suite *HandlerTestSuite) TestUpdateSecurityGroup() {
 	_, res, err = suite.ServeRequest(
 		http.MethodPatch,
 		"/organizations/:organization/security_groups/:id", fmt.Sprintf("/organizations/%s/security_groups/%s", suite.testOrganizationID.String(), actualGroup.ID),
-		suite.api.UpdateSecurityGroup, bytes.NewBuffer(updateBody),
+		func(c *gin.Context) {
+			c.Set("nexodus.secGroupsEnabled", "true")
+			suite.api.UpdateSecurityGroup(c)
+		},
+		bytes.NewBuffer(updateBody),
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, res.Code)


### PR DESCRIPTION
commit 199e7165be5dcfdd1e3dacbf61f5c9d03542676c
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue May 30 13:29:07 2023 -0400

    tests: Resolve ipam port conflict
    
    The unit tests fail when I try to run them on the same host as a
    running kind stack development environment because port 9090 is
    already in use. Change the port used in the test suite.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit e98be4e64090101b847e856fed4e52d803ffd9f7
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue May 30 13:24:23 2023 -0400

    apiserver: Put security groups behind a feature flag
    
    Add a security groups feature flag that is off by default. This flag
    must be turned on to allow security group creates/updates/deletes.
    
    This flag is turned on for the dev overlay only to facilitate ongoing
    development and testing of the feature.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>